### PR TITLE
issue #20 - subtract gas and fees from roi

### DIFF
--- a/__tests__/components/CollectionsTable.js
+++ b/__tests__/components/CollectionsTable.js
@@ -48,15 +48,15 @@ describe('CollectionsTable component', () => {
                 investment: 0.08,
                 sales: 0,
                 gasPaid: 0.02,
-                realized_roi: -0.08,
-                feesPaid: 0
+                feesPaid: 0,
+                realized_roi: -0.1
             },
             collectionB: {
                 investment: 0.5,
                 sales: 0.25,
-                realized_roi: -0.25,
                 gasPaid: 0.1,
-                feesPaid: 0.05
+                feesPaid: 0.05,
+                realized_roi: -0.4
             }
         };
 

--- a/__tests__/data/Trades.js
+++ b/__tests__/data/Trades.js
@@ -94,7 +94,7 @@ describe('getInvestmentStats()', () => {
                 gasPaid: 0.00084,
                 investment: 0.04,
                 mints: 0.04,
-                realized_roi: -0.04,
+                realized_roi: -0.04084,
                 sales: 0
             },
             collectionD: {

--- a/js/components/CollectionsTable.js
+++ b/js/components/CollectionsTable.js
@@ -159,7 +159,7 @@ export class CollectionsTable {
             const gas = data?.gasPaid ?? 0;
             const fees = data?.feesPaid ?? 0;
             const realizedRoi = data?.realized_roi ?? 0;
-            const possibleRoi = realizedRoi + minValue - gas - fees;
+            const possibleRoi = realizedRoi + minValue;
             const roiSentiment = realizedRoi > 0 ? 'positive' : 'negative';
             const possibleRoiSentiment = possibleRoi > 0 ? 'positive' : 'negative';
             const getCell = col => {

--- a/js/data/Trades.js
+++ b/js/data/Trades.js
@@ -129,7 +129,7 @@ export async function getInvestmentStats (address, provider) {
             gasPaid: parseFloat(formatEther(gasPaid), 10),
             feesPaid: parseFloat(formatEther(feesPaid), 10),
             investment: buys + mints,
-            realized_roi: sales - buys - mints
+            realized_roi: sales - buys - mints - parseFloat(formatEther(gasPaid), 10) - parseFloat(formatEther(feesPaid), 10)
         };
     }
 


### PR DESCRIPTION
tests aren't working for me at the moment. maybe give it a run-through. but seems straightforward.

i think it might be useful to add sales, gas and fees in the portfolio stats, so it's more visible how the possible ROI is calculated.